### PR TITLE
Correction to emonHub configuration template

### DIFF
--- a/src/emonTxV3_4_3Phase_Voltage.ino
+++ b/src/emonTxV3_4_3Phase_Voltage.ino
@@ -118,7 +118,7 @@ emonhub.conf node decoder settings for this sketch:
     nodename = 3phase
     [[[rx]]]
        names = powerL1, powerL2, powerL3, power4, Vrms, temp1, temp2, temp3, temp4, temp5, temp6, pulse
-       datacode = h,h,h,h,h,h,h,h,h,h,h,L
+       datacodes = h,h,h,h,h,h,h,h,h,h,h,L
        scales = 1,1,1,1,0.01,0.1,0.1,0.1,0.1,0.1,0.1,1
        units =W,W,W,W,V,C,C,C,C,C,C,p
 


### PR DESCRIPTION
See forum thread ["RFM2Pi thread dead: Caused by 3phase decoder settings"](https://community.openenergymonitor.org/t/rfm2pi-thread-dead-caused-by-3phase-decoder-settings/4517?u=pb66) and issue #4