### PR TITLE
Important fix

### DIFF
--- a/src/rfm.ino
+++ b/src/rfm.ino
@@ -4,11 +4,11 @@ Interface for the RFM69CW Radio Module
 
 #ifdef RFM69CW
 
-#include <avr/sleep.h>	
-#define REG_FIFO            0x00	
+#include <avr/sleep.h>
+#define REG_FIFO            0x00
 #define REG_OPMODE          0x01
 #define MODE_TRANSMITTER    0x0C
-#define REG_DIOMAPPING1     0x25	
+#define REG_DIOMAPPING1     0x25
 #define REG_IRQFLAGS2       0x28
 #define IRQ2_FIFOFULL       0x80
 #define IRQ2_FIFONOTEMPTY   0x40
@@ -18,7 +18,7 @@ Interface for the RFM69CW Radio Module
 
 
 void rfm_init(void)
-{	
+{
 	// Set up to drive the Radio Module
 	digitalWrite(RFMSELPIN, HIGH);
 	pinMode(RFMSELPIN, OUTPUT);
@@ -26,31 +26,31 @@ void rfm_init(void)
 	SPI.setBitOrder(MSBFIRST);
 	SPI.setDataMode(0);
 	SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
-	
+
 	// Initialise RFM69CW
-	do 
+	do
 		writeReg(0x2F, 0xAA); // RegSyncValue1
 	while (readReg(0x2F) != 0xAA) ;
 	do
-	  writeReg(0x2F, 0x55); 
+	  writeReg(0x2F, 0x55);
 	while (readReg(0x2F) != 0x55);
-	
+
 	writeReg(0x01, 0x04); // RegOpMode: RF_OPMODE_SEQUENCER_ON | RF_OPMODE_LISTEN_OFF | RF_OPMODE_STANDBY
 	writeReg(0x02, 0x00); // RegDataModul: RF_DATAMODUL_DATAMODE_PACKET | RF_DATAMODUL_MODULATIONTYPE_FSK | RF_DATAMODUL_MODULATIONSHAPING_00 = no shaping
 	writeReg(0x03, 0x02); // RegBitrateMsb  ~49.23k BPS
 	writeReg(0x04, 0x8A); // RegBitrateLsb
-	writeReg(0x05, 0x05); // RegFdevMsb: ~90 kHz 
+	writeReg(0x05, 0x05); // RegFdevMsb: ~90 kHz
 	writeReg(0x06, 0xC3); // RegFdevLsb
 	#ifdef RF12_868MHZ
-		writeReg(0x07, 0xD9); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0xD90000 = 868.00 MHz as used JeeLib  
+		writeReg(0x07, 0xD9); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0xD90000 = 868.00 MHz as used JeeLib
 		writeReg(0x08, 0x00); // RegFrfMid
 		writeReg(0x09, 0x00); // RegFrfLsb
-	#elif defined RF12_915MHZ // JeeLib uses 912.00 MHz	
-		writeReg(0x07, 0xE4); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0xE40000 = 912.00 MHz as used JeeLib 
+	#elif defined RF12_915MHZ // JeeLib uses 912.00 MHz
+		writeReg(0x07, 0xE4); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0xE40000 = 912.00 MHz as used JeeLib
 		writeReg(0x08, 0x00); // RegFrfMid
 		writeReg(0x09, 0x00); // RegFrfLsb
 	#else // default to 433 MHz band
-		writeReg(0x07, 0x6C); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0x6C8000 = 434.00 MHz as used JeeLib 
+		writeReg(0x07, 0x6C); // RegFrfMsb: Frf = Rf Freq / 61.03515625 Hz = 0x6C8000 = 434.00 MHz as used JeeLib
 		writeReg(0x08, 0x80); // RegFrfMid
 		writeReg(0x09, 0x00); // RegFrfLsb
 	#endif
@@ -58,7 +58,7 @@ void rfm_init(void)
 //	writeReg(0x0B, 0x20); // RegAfcCtrl:
 	writeReg(0x11, RFPWR); // RegPaLevel = 0x9F = PA0 on, +13 dBm  -- RFM12B equivalent: 0x99 | 0x88 (-10dBm) appears to be the max before the AC power supply fails @ 230 V mains. Min value is 0x80 (-18 dBm)
 	writeReg(0x1E, 0x2C); //
-	writeReg(0x25, 0x80); // RegDioMapping1: DIO0 is used as IRQ 
+	writeReg(0x25, 0x80); // RegDioMapping1: DIO0 is used as IRQ
 	writeReg(0x26, 0x03); // RegDioMapping2: ClkOut off
 	writeReg(0x28, 0x00); // RegIrqFlags2: FifoOverrun
 
@@ -77,10 +77,10 @@ void rfm_send(const byte *data, const byte size, const byte group, const byte no
         readReg(REG_FIFO);
 
     writeReg(REG_DIOMAPPING1, 0x00); 											// PacketSent
-		
+
 	volatile uint8_t txstate = 0;
 	byte i = 0;
-	uint16_t crc = _crc16_update(~0, group);	
+	uint16_t crc = _crc16_update(~0, group);
 
 	while(txstate < 7)
 	{
@@ -103,21 +103,19 @@ void rfm_send(const byte *data, const byte size, const byte group, const byte no
 	}
     //transmit buffer is now filled, transmit, flag that to the ISR
 	writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | MODE_TRANSMITTER);		// Transmit mode - 56 Bytes max payload
-   
+
     rfm_sleep();
 }
 
 void rfm_sleep(void)
-{   
+{
     // Put into sleep mode when buffer is empty
-	while (!(readReg(REG_IRQFLAGS2) & IRQ2_PACKETSENT))				// wait for transmission to complete (not present in JeeLib) 
-	    delay(1);													//   
+	while (!(readReg(REG_IRQFLAGS2) & IRQ2_PACKETSENT))				// wait for transmission to complete (not present in JeeLib)
+	    delay(1);													//
 
 	writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | 0x01); 		// Standby Mode
-	set_sleep_mode(SLEEP_MODE_IDLE);  								// SLEEP_MODE_STANDBY
-	sleep_mode();	
 	
-} 
+}
 
 
 

--- a/src/src.ino
+++ b/src/src.ino
@@ -99,7 +99,7 @@ int networkGroup = 210;                          //  wireless network group
 
 double vCal = 268.97;     // calculated value is 240:11.6 for UK transformer x 13:1 for resistor divider = 268.97
                           //   for the EU adapter use 260.00, for the USA adapter use 130.00
-#define VCAL_EU 251.7     // can use DIP switch 2 to set this as the starting value.                     
+#define VCAL_EU 248.2     // can use DIP switch 2 to set this as the starting value.                     
 double i1Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield
 double i2Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield
 double i3Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield

--- a/src/src.ino
+++ b/src/src.ino
@@ -14,7 +14,7 @@
     Three-phase energy monitor
     V 1.0   10/12/17 The original extensively modified with diverter code removed
                      and extended for 3-phase operation.
-    V 1.1   20/02/18 Fix: remove sleep
+    V 1.1   20/02/18 Sleep (sleep_mode()) removed from rfm_sleep() in rfm.ino
 
     History (single Phase energy diverter):
     2/12/12  first published version

--- a/src/src.ino
+++ b/src/src.ino
@@ -14,6 +14,7 @@
     Three-phase energy monitor
     V 1.0   10/12/17 The original extensively modified with diverter code removed
                      and extended for 3-phase operation.
+    V 1.1   20/02/18 Fix: remove sleep
 
     History (single Phase energy diverter):
     2/12/12  first published version
@@ -41,7 +42,7 @@
     For serial input, emonHub requires "datacode = 0" in place of "datacodes = ...." as above. ]
 
 */
-const int version = 10;                          // The firmware version 1.0
+const int version = 11;                          // The firmware version 1.0
 
 #define EMONTX_V34                               // Sets the I/O pin allocation.
                                                  // use EMONTX_V2 or EMONTX_V32 or EMONTX_V34 or EMONTX_SHIELD as appropriate
@@ -99,7 +100,7 @@ int networkGroup = 210;                          //  wireless network group
 
 double vCal = 268.97;     // calculated value is 240:11.6 for UK transformer x 13:1 for resistor divider = 268.97
                           //   for the EU adapter use 260.00, for the USA adapter use 130.00
-#define VCAL_EU 248.2     // can use DIP switch 2 to set this as the starting value.                     
+#define VCAL_EU 248.2     // can use DIP switch 2 to set this as the starting value.
 double i1Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield
 double i2Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield
 double i3Cal = 90.91;     // calculated value is 100A:0.05A for transformer / 22 Ohms for resistor = 90.91, or 60.6 for emonTx Shield


### PR DESCRIPTION
Removed rfm sleep_mode() because it also puts the processor into sleep. But that must not happen with a continues monitoring sketch. This fixes false/fluctuating current measurements of CT1.

All credits of the hard work to debug and fix this go to Robert Wall!